### PR TITLE
Fixes for the images building process

### DIFF
--- a/roles/install-grub/tasks/main.yml
+++ b/roles/install-grub/tasks/main.yml
@@ -1,4 +1,3 @@
-
 - name: Create GRUB directory
   become: true
   file:
@@ -19,7 +18,6 @@
   args:
     warn: no
 
-
 - name: Mount EFI
   mount:
       src: "{{ vyos_target_drive }}p2"
@@ -29,7 +27,7 @@
 
 - name: Install GRUB in the boot sector of {{ vyos_target_drive }}
   become: true
-  command: "chroot {{ vyos_install_root }} grub-install --no-floppy --root-directory=/boot {{ vyos_grub_drive }} --force" 
+  command: "chroot {{ vyos_install_root }} grub-install --no-floppy --target=i386-pc --root-directory=/boot {{ loop_device.stdout }} --force"
   args:
       creates: "{{ vyos_install_root }}/boot/grub/grubenv"
 

--- a/roles/setup-root-partition/tasks/main.yml
+++ b/roles/setup-root-partition/tasks/main.yml
@@ -1,34 +1,21 @@
 - name: Partition disk
   become: true
   command:
-      cmd: "sgdisk -a1 -n1:34:2047   -t1:EF02 -n2:2048:+256M -t2:EF00 -n3:0:0:+100% -t3:8300 {{ vyos_raw_img }}"
-
-- name: Create hybrid MBR
-  become: true
-  command:
-      cmd: "sgdisk -h -t1:EF02 -t2:EF00 -t3:8300 {{ vyos_raw_img }}"
+      cmd: "sgdisk -a1 -n1:34:2047 -t1:EF02 -n2:2048:+256M -t2:EF00 -n3:0:0:+100% -t3:8300 {{ vyos_raw_img }}"
 
 - name: Reread partitions from image and mount to loopback
   become: true
-  command: "kpartx -av  {{ vyos_raw_img }}"
+  shell: "kpartx -av {{ vyos_raw_img }} | awk '{ print $3 }'"
+  register: loop_partitions
 
-- name: Find the loop device that was used, map to mapper
+- name: Find loop device path
   become: true
-  shell: "losetup | grep vyos_raw_image.img | head -n1 | awk '{print $1}' | sed 's/dev/dev\\/mapper/g'"
-  register: result
+  shell: "losetup -l -O NAME,BACK-FILE | awk '{ if (match($2, \"{{ vyos_raw_img }}\")) print $1}'"
+  register: loop_device
 
-- name: Set vyos_target_drive.
+- name: Set vyos_target_drive fact
   set_fact:
-    vyos_target_drive: "{{ result.stdout }}"
-
-- name: Pull grub drive
-  become: true
-  shell: "losetup | grep vyos_raw_image.img | head -n1 | awk '{print $1}'"
-  register: result
-
-- name: Set vyos_grub_drive.
-  set_fact:
-    vyos_grub_drive: "{{ result.stdout }}"
+    vyos_target_drive: "{{ loop_device.stdout | regex_replace('^/dev/(loop.*)$', '/dev/mapper/\\1') }}"
 
 - name: Create a fileystem on EFI partition
   become: true
@@ -37,7 +24,6 @@
     device: "{{ vyos_target_drive }}p2"
     opts: "-n EFI -F 32 -s 1"
  
-
 - name: Create a fileystem on root partition
   become: true
   filesystem:

--- a/roles/unmount-all/tasks/main.yml
+++ b/roles/unmount-all/tasks/main.yml
@@ -36,13 +36,20 @@
   become: true
   mount:
     name: "{{ vyos_write_root }}"
-    src: "{{ vyos_target_drive }}"
-    fstype: "{{ vyos_root_fstype }}"
     state: absent
 
 - name: Remove image partitions
   become: true
   command: "kpartx -dv {{ vyos_raw_img }}"
+
+- name: Remove /dev/mapper entries
+  become: true
+  command: "dmsetup remove {{ item }}"
+  with_items: "{{ loop_partitions.stdout_lines }}"
+
+- name: Detach {{ loop_device.stdout }}
+  become: true
+  command: "losetup -d {{ loop_device.stdout }}"
 
 - name: Unmount {{ vyos_cd_squash_root }}
   become: true


### PR DESCRIPTION
  - Fixed GRUB installation on UEFI hosts. On UEFI machines GRUB will try to install EFI version by default, so we need to set `--target` on i386-pc version too;
  - Fixed /dev/mapper devices unmounting, removing, and loopback detach. `kpartx -d` does not detach devices from `/dev/mapper` at least in a testing environment (Debian Buster inside Docker). That why we need to run `dmsetup remove` directly for this. The same with a loopback device. If not do this, resources will be busy and all builds except the first one may fail;
  - Deleted hybrid MBR creating task. It has a wrong syntax and does not work, and it looks like it is needless anyway.