### PR TITLE
Fixes for Cloud-init, code optimization

### DIFF
--- a/roles/install-cloud-init/tasks/main.yml
+++ b/roles/install-cloud-init/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Get Debian version
-  become: true
-  command: chroot {{ vyos_install_root }} awk 'match($0, /VERSION=.*\((\w+)\)/, version) { print version[1] }' /etc/os-release
-  register: debian_version
 - name: Set VyOS branch name crux
   set_fact:
     vyos_branch: "crux"
@@ -28,7 +24,7 @@
   command: chroot {{ vyos_install_root }} apt-get update
 - name: Install cloud-init
   become: true
-  command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y cloud-init cloud-utils
+  command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y cloud-init cloud-utils ifupdown
 - name: apt-get clean
   become: true
   command: chroot {{ vyos_install_root }} apt-get clean
@@ -62,6 +58,12 @@
   when:
     - cloud_init_disable_config is defined
     - cloud_init_disable_config == "true"
+- name: Add source-directory to the /etc/network/interfaces
+  become: true
+  lineinfile:
+    path: "{{ vyos_install_root }}/etc/network/interfaces"
+    line: "source-directory /etc/network/interfaces.d"
+    create: yes
 - name: restore original resolv.conf
   become: true
   command: mv /tmp/resolv.conf {{ vyos_install_root }}/etc/resolv.conf

--- a/roles/install-custom-packages/tasks/main.yml
+++ b/roles/install-custom-packages/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Get Debian version
-  become: true
-  command: chroot {{ vyos_install_root }} awk 'match($0, /VERSION=.*\((\w+)\)/, version) { print version[1] }' /etc/os-release
-  register: debian_version
 - name: Set VyOS branch name crux
   set_fact:
     vyos_branch: "crux"
@@ -33,13 +29,10 @@
     dest: "{{ vyos_install_root }}/tmp/custom_debs/"
 - name: Install custom packages from a list
   command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y --no-install-recommends {{ lookup('file', 'files/custom_packages_list.txt') }}
-- name: Check if custom debs directory exists
-  stat:
-    path: "{{ vyos_install_root }}/tmp/custom_debs/"
-  register: custom_debs_dir
 - name: Install custom packages from deb files
-  command: chroot {{ vyos_install_root }} dpkg -i --force-depends -R /tmp/custom_debs/
-  when: custom_debs_dir.stat.exists
+  command:
+    cmd: "chroot {{ vyos_install_root }} dpkg -i --force-depends /tmp/custom_debs/{{ item | basename }}"
+  with_fileglob: "{{ vyos_install_root }}/tmp/custom_debs/*.deb"
 - name: Install missed dependencies
   command: chroot {{ vyos_install_root }} apt-get -f -y install
 - name: Delete DEB packages

--- a/roles/install-guest-agent/tasks/main.yml
+++ b/roles/install-guest-agent/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Get Debian version
-  become: true
-  command: chroot {{ vyos_install_root }} awk 'match($0, /VERSION=.*\((\w+)\)/, version) { print version[1] }' /etc/os-release
-  register: debian_version
 - name: Set VyOS branch name crux
   set_fact:
     vyos_branch: "crux"

--- a/templates/debian.list.j2
+++ b/templates/debian.list.j2
@@ -8,7 +8,7 @@ deb http://dev.packages.vyos.net/repositories/crux/debian crux main
 deb http://deb.debian.org/debian buster main contrib non-free
 deb http://deb.debian.org/debian buster-updates main contrib non-free
 deb http://security.debian.org/debian-security/ buster/updates main contrib non-free
-deb http://dev.packages.vyos.net/repositories/{{ debian_version.stdout }} {{ debian_version.stdout }} main
+deb http://dev.packages.vyos.net/repositories/equuleus equuleus main
 {% else %}
 deb http://deb.debian.org/debian buster main contrib non-free
 deb http://deb.debian.org/debian buster-updates main contrib non-free


### PR DESCRIPTION
  - Cleaned up APT configuration code.
  - Added ifupdown to Cloud-init install. This is required for all datasources that fetch data from remote hosts.
  - Fixed error that stops playbook if the `custom_debs` directory is empty and `-e custom_packages=true` is used.