### PR TITLE
Trivial: builds require git

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You need a machine with at least 20 GB free space with Debian 10 (bare-metal, vi
 
 ```
 sudo apt update
-sudo apt install -y ansible python
+sudo apt install -y ansible python git
 ```
 
 If you want to build an OVA image, you also need `ovftool` from VMware. It should be downloaded from the [VMware site](https://code.vmware.com/tool/ovf). Also, you need a private key to sign an OVA file. It can be generated with the next command:


### PR DESCRIPTION
A stock debian 10 cloud image does not include git, so you should explicitly call it out as a dependancy.