### PR TITLE
Use debian 11 (bullseye) sources for apt

### DIFF
--- a/templates/debian.list.j2
+++ b/templates/debian.list.j2
@@ -10,8 +10,8 @@ deb http://deb.debian.org/debian buster-updates main contrib non-free
 deb http://security.debian.org/debian-security/ buster/updates main contrib non-free
 deb http://dev.packages.vyos.net/repositories/equuleus equuleus main
 {% else %}
-deb http://deb.debian.org/debian buster main contrib non-free
-deb http://deb.debian.org/debian buster-updates main contrib non-free
-deb http://security.debian.org/debian-security/ buster/updates main contrib non-free
+deb http://deb.debian.org/debian bullseye main contrib non-free
+deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
 deb http://dev.packages.vyos.net/repositories/current current main
 {% endif %}


### PR DESCRIPTION
Update the apt repositories (used for installing cloud-init, guest-agent and custom-packages) to the debian 11 ones.