### PR TITLE
T4298: solve ansible warnings

### DIFF
--- a/hosts
+++ b/hosts
@@ -10,5 +10,5 @@ localhost
 [hyperv]
 localhost
 
-[vagrant-libvirt]
+[vagrant_libvirt]
 localhost

--- a/roles/install-custom-packages/tasks/main.yml
+++ b/roles/install-custom-packages/tasks/main.yml
@@ -31,7 +31,6 @@
   become: true
   command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y --no-install-recommends {{ lookup('file', 'files/custom_packages_list.txt') }}
 - name: Install custom packages from deb files
-  command:
   become: true
   command: chroot {{ vyos_install_root }} dpkg -i --force-depends /tmp/custom_debs/{{ item | basename }}
   with_fileglob: "{{ vyos_install_root }}/tmp/custom_debs/*.deb"

--- a/vagrant-libvirt.yml
+++ b/vagrant-libvirt.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: vagrant-libvirt
+- hosts: vagrant_libvirt
   become: True
   gather_facts: False
   connection: local


### PR DESCRIPTION
Fix group name and remove obsolete empty command to remove the warnings from ansible.