### PR TITLE
Remove aufs modprobe

### DIFF
--- a/hyperv.yml
+++ b/hyperv.yml
@@ -13,7 +13,6 @@
     cloud_init_ds_list: "{{ cloud_init_ds_string.split(',') }}"
   roles:
     - install-packages
-    - load-modules
     - download-iso
     - mount-iso
     - get-version

--- a/qemu.yml
+++ b/qemu.yml
@@ -16,7 +16,6 @@
             name: '{{ roleinputvar }}'
           loop:
             - install-packages
-            - load-modules
             - download-iso
             - mount-iso
             - get-version

--- a/raw.yml
+++ b/raw.yml
@@ -16,7 +16,6 @@
             name: '{{ roleinputvar }}'
           loop:
             - install-packages
-            - load-modules
             - download-iso
             - mount-iso
             - get-version

--- a/roles/load-modules/tasks/main.yml
+++ b/roles/load-modules/tasks/main.yml
@@ -1,5 +1,0 @@
-- name: modprobe aufs
-  become: true
-  modprobe:
-    name: aufs
-    state: present

--- a/roles/load-modules/tests/inventory
+++ b/roles/load-modules/tests/inventory
@@ -1,2 +1,0 @@
-localhost
-

--- a/roles/load-modules/tests/test.yml
+++ b/roles/load-modules/tests/test.yml
@@ -1,4 +1,0 @@
----
-- hosts: localhost
-  roles:
-    - load-modules

--- a/vmware.yml
+++ b/vmware.yml
@@ -19,7 +19,6 @@
             name: '{{ roleinputvar }}'
           loop:
             - install-packages
-            - load-modules
             - download-iso
             - mount-iso
             - get-version


### PR DESCRIPTION
Since commit d6532ad9f6d6317, overlayfs is used instead of `aufs`. It is then safe to remove the `modprobe aufs` task, which is unused.
