### PR TITLE
T4278: Fix config template

### DIFF
--- a/roles/install-config/defaults/main.yml
+++ b/roles/install-config/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+enable_dhcp: False
+enable_ssh: False


### PR DESCRIPTION
The configuration template `roles/install-config/templates/config.boot.j2` has been updated in commit db1b4f2079a for libvirt provider.

However, variables `enable_dhcp` and `enable_ssh` are not declared except in playbook `vagrant-libvirt.yml`, which causes an error when using another playbook.

This commit adds a default value in role `install-config`, to fix this issue.
