### PR TITLE
iso_local file gets overridden

### DIFF
--- a/roles/download-iso/tasks/main.yml
+++ b/roles/download-iso/tasks/main.yml
@@ -3,3 +3,4 @@
     url: "{{ vyos_iso_url }}"
     dest: "{{ vyos_iso_local }}"
     force: no
+  when: not vyos_iso_local is exists


### PR DESCRIPTION
Hello there!

I am building custom VyOS images for myself and wanted to use my custom iso for a Vultr deployment.
I ran the following command:

```
ansible-playbook -e "iso_local=../vyos-1.3-rolling-2022-04-24-13-48-amd64.iso disk_size=2 cloud_init=true keep_user=true cloud_init_ds=Vultr" qemu.yml
```

However the playbook always replaced my local .iso with the downloaded iso. I stumbled across the following bug in the ansible repository regarding the `get_url` force behavior: https://github.com/ansible/ansible/issues/64016
The `dst` file gets replaced when the checksum of `src` and `dst` do not match, regardless of the `force` setting.

Please let me know if there's something to improve from my side.

Thanks!
Sebastian

