### PR TITLE
Revert "Small fixes for integration with Ansible Tower"

### DIFF
--- a/roles/install-cloud-init-wrapper/tasks/main.yml
+++ b/roles/install-cloud-init-wrapper/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Check if we need to install Cloud-Init
   include_role:
-    name: vyos-vm-images/install-cloud-init
+    name: install-cloud-init
   when: cloud_init == "true"
 - name: Set Cloud-Init tag for image file name
   set_fact:

--- a/roles/install-cloud-init/tasks/main.yml
+++ b/roles/install-cloud-init/tasks/main.yml
@@ -21,7 +21,7 @@
     dest: "{{ vyos_install_root }}/etc/resolv.conf"
 - name: apt-get update
   become: true
-  command: chroot {{ vyos_install_root }} apt-get -o Acquire::Check-Valid-Until=false update
+  command: chroot {{ vyos_install_root }} apt-get update
 - name: Install cloud-init
   become: true
   command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y cloud-init cloud-utils ifupdown

--- a/roles/install-packages/tasks/main.yml
+++ b/roles/install-packages/tasks/main.yml
@@ -21,4 +21,3 @@
       - squashfs-tools
       - xorriso
     state: present
-    force_apt_get: yes


### PR DESCRIPTION
Reverts vyos/vyos-vm-images#32
Changes brake local building process. We had to have these changes for fork vyos-cloud-images in Ansible Tower but now  we are going to deprecate this repo usage (vyos-cloud-images). Thus we can simply revert changes.