### PR TITLE
cloud init install force yes to avoid apt errors

### DIFF
--- a/roles/install-cloud-init/tasks/main.yml
+++ b/roles/install-cloud-init/tasks/main.yml
@@ -24,7 +24,7 @@
   command: chroot {{ vyos_install_root }} apt-get update
 - name: Install cloud-init
   become: true
-  command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y cloud-init cloud-utils ifupdown
+  command: chroot {{ vyos_install_root }} apt-get -t {{ vyos_branch | default('current') }} install -y --force-yes cloud-init cloud-utils ifupdown
 - name: apt-get clean
   become: true
   command: chroot {{ vyos_install_root }} apt-get clean


### PR DESCRIPTION
This is needed for Crux version OVA builds. --force-yes parameter is almost deprecated but we need it for backward compatibility because even apt in debin 10 do not recognize newer --allow-* commands