### PR TITLE
Create loop device

### DIFF
--- a/qemu.yml
+++ b/qemu.yml
@@ -16,6 +16,7 @@
             name: '{{ roleinputvar }}'
           loop:
             - install-packages
+            - create-loop-dev
             - download-iso
             - mount-iso
             - get-version

--- a/roles/create-loop-dev/tasks/main.yml
+++ b/roles/create-loop-dev/tasks/main.yml
@@ -1,3 +1,4 @@
 - name: Create loopback devices
   shell: "[ ! -e /dev/loop{{ item }} ]] && mknod -m 0666 /dev/loop{{ item }} b 7 {{ item }}"
   loop: "{{ range(0, 20)|list }}"
+  failed_when: false

--- a/roles/create-loop-dev/tasks/main.yml
+++ b/roles/create-loop-dev/tasks/main.yml
@@ -1,4 +1,10 @@
+- name: Are we in a docker container ?
+  stat:
+    path: "/.dockerenv"
+  register: docker
+
 - name: Create loopback devices
   shell: "[ ! -e /dev/loop{{ item }} ]] && mknod -m 0666 /dev/loop{{ item }} b 7 {{ item }}"
   loop: "{{ range(0, 20)|list }}"
   failed_when: false
+  when: docker.stat.exists

--- a/roles/create-loop-dev/tasks/main.yml
+++ b/roles/create-loop-dev/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Create loopback devices
+  shell: "[ ! -e /dev/loop{{ item }} ]] && mknod -m 0666 /dev/loop{{ item }} b 7 {{ item }}"
+  loop: "{{ range(0, 20)|list }}"

--- a/roles/create-loop-dev/tests/inventory
+++ b/roles/create-loop-dev/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/create-loop-dev/tests/test.yml
+++ b/roles/create-loop-dev/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+    - create-loop-dev


### PR DESCRIPTION
Hi, 
With docker, loopback pseudo devices `/dev/loop*` are not created automatically. 
This cause errors during iso mount and squashfs mount.

This MR will populate many loopback files if the playbook is run inside a docker container.
