### PR TITLE
Added `copy-custom-files` role.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ You need to copy the ISO image with VyOS to /tmp/vyos.iso before running ansible
     -e custom_packages=true
     ```
 
+- Copy custom files. All files from inside the `files/custom_files/` directory will be copied to the target filesystem recursively:
+
+    ```
+    -e custom_files=true
+    ```
+
 - Enable DHCP on eth0 (default: `false`):
 
     ```

--- a/qemu.yml
+++ b/qemu.yml
@@ -29,6 +29,7 @@
             - install-cloud-init-wrapper
             - install-guest-agent-wrapper
             - install-custom-packages-wrapper
+            - copy-custom-files
             - fstrim
             - unmount-pre
             - create-pxe-archive

--- a/roles/copy-custom-files/tasks/main.yml
+++ b/roles/copy-custom-files/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Copy custom files to the system, preserving paths
+  become: true
+  copy:
+    src: "files/custom_files/"
+    dest: "{{ vyos_install_root }}"
+    force: true
+  when: custom_files is defined

--- a/roles/copy-custom-files/tests/inventory
+++ b/roles/copy-custom-files/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/copy-custom-files/tests/test.yml
+++ b/roles/copy-custom-files/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+    - copy-custom-files


### PR DESCRIPTION
Sometimes we need to add extra files, like configurations. This role allows to copy them into the installation directory.