### PR TITLE
T5899: Use default repo bookworm if vyos_version is unknowm

### DIFF
--- a/templates/debian.list.j2
+++ b/templates/debian.list.j2
@@ -10,8 +10,8 @@ deb http://deb.debian.org/debian buster-updates main contrib non-free
 deb http://security.debian.org/debian-security/ buster/updates main contrib non-free
 deb http://dev.packages.vyos.net/repositories/equuleus equuleus main
 {% else %}
-deb http://deb.debian.org/debian bullseye main contrib non-free
-deb http://deb.debian.org/debian bullseye-updates main contrib non-free
-deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+deb http://deb.debian.org/debian bookworm main contrib non-free
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free
+deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free
 deb http://dev.packages.vyos.net/repositories/current current main
 {% endif %}


### PR DESCRIPTION
https://vyos.dev/T5899
Replace debian.list `bullseye` with `bookworm` if `vyos_version` is not defined