### PR TITLE
ansible remove legacy shell args warning

### DIFF
--- a/roles/install-grub/tasks/main.yml
+++ b/roles/install-grub/tasks/main.yml
@@ -15,8 +15,6 @@
          mount --bind /proc {{ vyos_install_root }}/proc &&
          mount --bind /sys {{ vyos_install_root }}/sys &&
          mount --bind {{ vyos_write_root }} {{ vyos_install_root }}/boot 
-  args:
-    warn: no
 
 - name: Create efi directory
   become: true


### PR DESCRIPTION
On the newest systems like Debian12 the asnible shell args: warn is legacy
```
The warn parameter for shell was deprecated in Ansible 2.11 and removed in Ansible 2.14
```

It cause of
```
TASK [install-grub : Mount and bind /dev /proc /sys and /mnt/wroot/boot to /mnt/inst_root] **********************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends."}

```

Delete args: warn

After the fix:
```
TASK [install-grub : Mount and bind /dev /proc /sys and /mnt/wroot/boot to /mnt/inst_root] **********************************************************************************************
changed: [localhost]
...

PLAY RECAP ******************************************************************************************************************************************************************************
localhost                  : ok=80   changed=60   unreachable=0    failed=0    skipped=19   rescued=0    ignored=0   

root@d5e853e861c4:/vm-build/vyos-vm-images# ls /tmp
mc-root  vyos-1.4.0-cloud-init-2G-qemu.qcow2
```
Build host docker version:
```
root@d5e853e861c4:/vm-build/vyos-vm-images# cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
root@d5e853e861c4:/vm-build/vyos-vm-images# cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
root@d5e853e861c4:/vm-build/vyos-vm-images# 

```
