### PR TITLE
Added build-essential in Dockerfile to Fix VMware Playbook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y \
     unzip \
     zlib1g-dev \
     squashfs-tools \
-    xorriso
+    xorriso \
+    build-essential
 
 # Install not required dependencies
 RUN apt-get install -y \


### PR DESCRIPTION
The VMware playbook fails because it's not able to compile the **open-vmdk** package since **make** is not found (the whole **build-essential** package is missing from the Docker image). **This commit add the build-essential package in the Dockerfile.**

**Issue:**

```
TASK [install-open-vmdk : Build open-vmdk] *****************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to find required executable make in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}

```
**RCA:**
```
lbiosa@windesk01:~/vyos-vm-images$ docker run --rm -it --privileged -v $(pwd):/vm-build -v $(pwd)/images:/images -w /vm-build vyos-vm-images:latest bash
root@6a8cd597625c:/vm-build/vyos-vm-images# cd /tmp/open-vmdk-master/
root@6a8cd597625c:/tmp/open-vmdk-master# make
bash: make: command not found
```

**Solution:**
```
root@6a8cd597625c:/tmp/open-vmdk-master# apt install build-essential -y
root@6a8cd597625c:/tmp/open-vmdk-master# make
for x in vmdk ova ova-compose templates; do make -C $x all; done
make[1]: Entering directory '/tmp/open-vmdk-master/vmdk'
mkdir -p ../build/vmdk
gcc -W -Wall -O2 -g  -c -o ../build/vmdk/flat.o flat.c
gcc -W -Wall -O2 -g  -c -o ../build/vmdk/sparse.o sparse.c
gcc -W -Wall -O2 -g  -c -o ../build/vmdk/mkdisk.o mkdisk.c
gcc -o ../build/vmdk/vmdk-convert ../build/vmdk/flat.o ../build/vmdk/sparse.o ../build/vmdk/mkdisk.o -g -lz
make[1]: Leaving directory '/tmp/open-vmdk-master/vmdk'
make[1]: Entering directory '/tmp/open-vmdk-master/ova'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/tmp/open-vmdk-master/ova'
make[1]: Entering directory '/tmp/open-vmdk-master/ova-compose'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/tmp/open-vmdk-master/ova-compose'
make[1]: Entering directory '/tmp/open-vmdk-master/templates'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/tmp/open-vmdk-master/templates'
```