### PR TITLE
Add EFI boot VMware config if parttable_type=gpt is set

### DIFF
--- a/roles/vmware/templates/vyos_vmware_image.ovf.j2
+++ b/roles/vmware/templates/vyos_vmware_image.ovf.j2
@@ -240,6 +240,10 @@
       </ovf:Item>
       <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="true"/>
+      {%- if parttable_type == 'gpt' -%}
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      {%- endif -%}
     </VirtualHardwareSection>
   </VirtualSystem>
 </ovf:Envelope>


### PR DESCRIPTION
If `vmware.yml` playbook is executed with `parttable_type=gpt` argument, the following configuration items must be added to the OVA/OVF file otherwise the VM will not be bootable.

```
<vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
<vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
```