### PR TITLE
Fix the "Unsupported element 'Reservation'" Error in VMware OVA during Import

### DIFF
--- a/roles/vmware/templates/vyos_vmware_image.ovf.j2
+++ b/roles/vmware/templates/vyos_vmware_image.ovf.j2
@@ -149,27 +149,27 @@
         <rasd:Description>Memory Size</rasd:Description>
         <rasd:ElementName xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">512 MB of memory</rasd:ElementName>
         <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">2</rasd:InstanceID>
+        <rasd:Reservation>512</rasd:Reservation>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>512</rasd:VirtualQuantity>
-        <rasd:Reservation>512</rasd:Reservation>
       </Item>
       <Item configuration="4CPU-16GB">
         <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
         <rasd:Description>Memory Size</rasd:Description>
         <rasd:ElementName xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">16 GB of memory</rasd:ElementName>
         <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">2</rasd:InstanceID>
+        <rasd:Reservation>16384</rasd:Reservation>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>16384</rasd:VirtualQuantity>
-        <rasd:Reservation>16384</rasd:Reservation>
       </Item>
       <Item configuration="8CPU-32GB">
         <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
         <rasd:Description>Memory Size</rasd:Description>
         <rasd:ElementName xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">32 GB of memory</rasd:ElementName>
         <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">2</rasd:InstanceID>
+        <rasd:Reservation>32768</rasd:Reservation>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>32768</rasd:VirtualQuantity>
-        <rasd:Reservation>32768</rasd:Reservation>
       </Item>
       {%- else -%}
       <Item>


### PR DESCRIPTION
Hi,

**Issue:** If the `vmware.yml` playbook is used and you try to import the OVA file you get the following error:
![Screenshot 2024-01-15 001109](https://github.com/vyos/vyos-vm-images/assets/56867176/61992d65-f385-4e6c-a021-2565f43da3dd)

Seems that this is a known issue and other peoples are facing it https://forum.vyos.io/t/unable-to-create-vm-with-ova-file-in-esxi/8560.

**Solution:** https://forum.vyos.io/t/ova-template-broken-with-latest-change/7246. I've changed the order in the `vyos_vmware_image.ovf.j2` and the generated OVA is imported correctly.

Regards
Lorenzo
