### PR TITLE
Removed needless pause action in GRUB install

### DIFF
--- a/roles/install-grub-v2/tasks/main.yml
+++ b/roles/install-grub-v2/tasks/main.yml
@@ -20,10 +20,6 @@
       boot: no
   when: partition_num_efi is defined
 
-- name: Pause
-  pause:
-    prompt: "Continue?"
-
 - name: Copy installer
   become: true
   copy:


### PR DESCRIPTION
It was used for debugging and left accidentally in the code.